### PR TITLE
Add support for truncated variant, SHA512/256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+config.h
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8.12)
 project(sha512)
 
 option(ONLY_LIB "Build the project as a library only" OFF)

--- a/SHA512.c
+++ b/SHA512.c
@@ -112,17 +112,7 @@ PaddedMsg preprocess(uint8_t *msg, size_t len)
     return padded;
 }
 
-// Step 2:
-// Parse the padded message into N 1024-bit blocks
-// Each block separated into 64-bit words (therefore 16 per block)
-// Returns an array of 8 64 bit words corresponding to the hashed value
-uint64_t *getHash(PaddedMsg *p)
-{
-    size_t N = p->length / SHA512_MESSAGE_BLOCK_SIZE;
-    //printf("Number of blocks = %zu\n", N);
-    
-    // initial hash value
-    uint64_t h[8] = {
+uint64_t sha512_iv[8] = {
         0x6A09E667F3BCC908,
         0xBB67AE8584CAA73B,
         0x3C6EF372FE94F82B,
@@ -131,7 +121,31 @@ uint64_t *getHash(PaddedMsg *p)
         0x9B05688C2B3E6C1F,
         0x1F83D9ABFB41BD6B,
         0x5BE0CD19137E2179
-    };
+};
+
+uint64_t sha512_256_iv[8] = {
+	0x22312194FC2BF72C,
+	0x9F555FA3C84C64C2,
+	0x2393B86B6F53B151,
+       	0x963877195940EABD,
+	0x96283EE2A88EFFE3,
+       	0xBE5E1E2553863992,
+       	0x2B0199FC2C85B8AA,
+       	0x0EB72DDC81C52CA2
+};
+
+
+// Step 2:
+// Parse the padded message into N 1024-bit blocks
+// Each block separated into 64-bit words (therefore 16 per block)
+// Returns an array of 8 64 bit words corresponding to the hashed value
+uint64_t *getHash(PaddedMsg *p, uint64_t* iv)
+{
+    size_t N = p->length / SHA512_MESSAGE_BLOCK_SIZE;
+    //printf("Number of blocks = %zu\n", N);
+    
+    // initial hash value
+    uint64_t* h = iv;
     
 #if MACHINE_BYTE_ORDER == LITTLE_ENDIAN
     // Convert byte order of message to big endian
@@ -184,5 +198,14 @@ uint64_t *getHash(PaddedMsg *p)
 uint64_t *SHA512Hash(uint8_t *input, size_t len)
 {
     PaddedMsg paddedMsg = preprocess(input, len);
-    return getHash(&paddedMsg);
+    return getHash(&paddedMsg, sha512_iv);
 }
+
+uint64_t *SHA512_256Hash(uint8_t *input, size_t len)
+{
+    PaddedMsg paddedMsg = preprocess(input, len);
+    return getHash(&paddedMsg, sha512_256_iv);
+}
+
+
+

--- a/SHA512.h
+++ b/SHA512.h
@@ -19,9 +19,10 @@
 PaddedMsg preprocess(uint8_t *msg, size_t len);
 
 /// Returns the sha-512 hash corresponding to the padded message: Return value must be free()'d
-uint64_t *getHash(PaddedMsg *p);
+uint64_t *getHash(PaddedMsg *p, uint64_t* iv);
 
 /// Wrapper for hashing methods, up to caller to free the return value
 uint64_t *SHA512Hash(uint8_t *input, size_t len);
+uint64_t *SHA512_256Hash(uint8_t *input, size_t len);
 
 #endif //__SHA512_H_

--- a/main.c
+++ b/main.c
@@ -13,10 +13,11 @@ typedef enum Mode
 {
     MODE_256 = 0x01,
     MODE_512 = 0x02,
-    MODE_BOTH = (MODE_256 | MODE_512)
+    MODE_512_256 = 0x04,
+    MODE_ALL = (MODE_256 | MODE_512 | MODE_512_256),
 } Mode;
 
-Mode progMode = MODE_BOTH;
+Mode progMode = MODE_ALL;
 
 /// Prints the checksum of the given file
 void getChecksum(char *filename)
@@ -72,6 +73,15 @@ void getChecksum(char *filename)
         printf("\n");
         free(checksum2);
     }
+
+    if (progMode & MODE_512_256)
+    {
+        uint64_t *checksum = SHA512Hash((uint8_t*)fileContents, fileSize);
+        for (int i = 0; i < HASH_ARRAY_LEN/2; ++i)
+            printf("%016" PRIx64 , checksum[i]);
+        printf("\n");
+        free(checksum);
+    }
     
     free(fileContents);
 }
@@ -80,10 +90,10 @@ void getChecksum(char *filename)
 void printOptions(char *arg0)
 {
     printf("Usage: %s [OPTION or STRING]\n", arg0);
-    printf("Calculate the SHA-512 and SHA-256 hashes of an input string, or the checksum of a given file.\n\n");
+    printf("Calculate the SHA-512, SHA-512/256 or SHA-256 hashes of an input string, or the checksum of a given file.\n\n");
     printf("Options:\n");
-    printf("-f, --file [FILENAME] Calculate both the SHA-512 & SHA-256 checksums of the file.\n");
-    printf("-m, --mode [MODE] Calculates only the SHA256 digest with mode = 256, or only the SHA512 digest with mode = 512\n");
+    printf("-f, --file [FILENAME] Calculate the SHA-512, SHA-512/256 & SHA-256 checksums of the file.\n");
+    printf("-m, --mode [MODE] Calculates only the SHA256 digest with mode = 256, or only the SHA512 digest with mode = 512, or the truncated variant SHA512/256 with mode = 512_256\n");
     printf("-h, --help Print command line options\n\n");   
 }
 
@@ -124,6 +134,15 @@ void hashInput(int argc, int inputPos, char **argv)
         printf("\n");
         free(argHash2);
     }
+    if (progMode & MODE_512_256)
+    {
+        uint64_t *argHash3 = SHA512_256Hash((uint8_t*)argStr, strlen(argStr));
+        printf("SHA-512/256 hash of command line input: \n");
+        for (int i = 0; i < HASH_ARRAY_LEN/2; ++i)
+            printf("%08" PRIx64 , argHash3[i]);
+        printf("\n");
+        free(argHash3);
+    }
     
     free(argStr);
 }
@@ -156,10 +175,13 @@ int main(int argc, char **argv)
                         {
                             char *str256 = "256";
                             char *str512 = "512";
+			    char *str512_256 = "512_256";
                             if (strncmp(argv[i + 1], str256, 3) == 0)
                                 progMode = MODE_256;
                             if (strncmp(argv[i + 1], str512, 3) == 0)
                                 progMode = MODE_512;
+                            if (strncmp(argv[i + 1], str512_256, 7) == 0)
+                                progMode = MODE_512_256;
 
                             if (argc > i + 2)
                                 inputPos = i + 2;


### PR DESCRIPTION
The SHA512/256 is the same as SHA512 but with a different set of initial values, and the result is just the output but truncated for 256 bits.

I suppose you weren't expecting this enhancement.  I did the work mainly as a way to understand the cryptography; a learning exercise.